### PR TITLE
Stelle Suche auf ts_vector um

### DIFF
--- a/PostNAS_SearchDialog.py
+++ b/PostNAS_SearchDialog.py
@@ -30,25 +30,55 @@ class PostNAS_SearchDialog(QtGui.QDialog, Ui_PostNAS_SearchDialogBase):
         super(PostNAS_SearchDialog, self).__init__(parent)
         self.setupUi(self)
         self.iface = iface
-        
+
         self.map = QgsMapLayerRegistry.instance()
         self.treeWidget.setColumnCount(1)
-        
+
     def on_lineEdit_returnPressed(self):
         searchString = self.lineEdit.text()
+        searchString = searchString.replace(" ", " & ")
         QApplication.setOverrideCursor(Qt.WaitCursor)
         if(len(searchString) > 0):
             self.loadDbSettings()
             self.db.open()
             query = QSqlQuery(self.db)
-            query.prepare("SELECT ax_flurstueck.gemarkungsnummer,ax_gemarkung.bezeichnung,ax_flurstueck.flurnummer,ax_flurstueck.zaehler,ax_flurstueck.nenner,ax_flurstueck.flurstueckskennzeichen FROM ax_flurstueck JOIN ax_gemarkung ON ax_flurstueck.land = ax_gemarkung.land AND ax_flurstueck.gemarkungsnummer = ax_gemarkung.gemarkungsnummer WHERE ax_flurstueck.flurstueckskennzeichen LIKE :search1 OR lpad(ax_flurstueck.land::text,2,'0') || lpad(ax_flurstueck.gemarkungsnummer::text,4,'0') || '-' || lpad(ax_flurstueck.flurnummer::text,3,'0') || '-' || lpad(ax_flurstueck.zaehler::text,5,'0') || '/' || CASE WHEN nenner IS NULL THEN '000' ELSE lpad(ax_flurstueck.nenner::text,3,'0') END LIKE :search2 OR ax_flurstueck.gemarkungsnummer::text || '-' || ax_flurstueck.flurnummer::text || '-' || ax_flurstueck.zaehler::text || '/' || CASE WHEN nenner IS NULL THEN '0' ELSE ax_flurstueck.nenner::text END LIKE :search3 OR lower(ax_gemarkung.bezeichnung) ILIKE :search4 OR to_tsvector('simple',lower(replace(ax_gemarkung.bezeichnung,'-',' ')) || ' ' || ax_flurstueck.gemarkungsnummer || ' ' || ax_flurstueck.flurnummer || ' ' || zaehler || ' ' || CASE WHEN nenner IS NOT NULL THEN nenner::character ELSE '' END) @@ to_tsquery('simple',:search5) ORDER BY ax_gemarkung.bezeichnung,flurstueckskennzeichen")
-            query.bindValue(":search1",  "%" + unicode(searchString) + "%")
-            query.bindValue(":search2",  "%" + unicode(searchString) + "%")
-            query.bindValue(":search3",  "%" + unicode(searchString) + "%")
-            query.bindValue(":search4",  "%" + unicode(searchString.lower()) + "%")
-            query.bindValue(":search5",  unicode(searchString.replace('-', '&').replace(' ', '&')))
+            query.prepare(
+                "SELECT ax_flurstueck.gemarkungsnummer, \
+                ax_gemarkung.bezeichnung, \
+                ax_flurstueck.flurnummer, \
+                ax_flurstueck.zaehler, \
+                ax_flurstueck.nenner, \
+                ax_flurstueck.flurstueckskennzeichen \
+                FROM ax_flurstueck \
+                JOIN ax_gemarkung ON ax_flurstueck.land::text = ax_gemarkung.land::text \
+                    AND ax_flurstueck.gemarkungsnummer::text = ax_gemarkung.gemarkungsnummer::text \
+                WHERE to_tsvector('german'::regconfig, \
+                    ((((((((((((((((((((((( \
+                    ax_flurstueck.flurstueckskennzeichen::text || \' \"\'::text) || \
+                    lpad(ax_flurstueck.land::text, 2, \'0\'::text)) || \
+                    lpad(ax_flurstueck.gemarkungsnummer::text, 4, \'0\'::text)) || \
+                    \'-\'::text) || lpad(ax_flurstueck.flurnummer::text, 3, \'0\'::text)) || \
+                    \'-\'::text) || lpad(ax_flurstueck.zaehler::text, 5, \'0\'::text)) || \'/\'::text) || \
+                    CASE \
+                        WHEN ax_flurstueck.nenner IS NULL THEN \'000\'::text \
+                        ELSE lpad(ax_flurstueck.nenner::text, 3, \'0\'::text) \
+                    END) || \'\" \"\'::text) || ax_flurstueck.gemarkungsnummer::text) || \
+                    \'-\'::text) || ax_flurstueck.flurnummer::text) || \'-\'::text) || \
+                    ax_flurstueck.zaehler::text) || \'/\'::text) || \
+                    CASE \
+                        WHEN ax_flurstueck.nenner IS NULL THEN \'0\'::text \
+                        ELSE ax_flurstueck.nenner::text \
+                    END) || \'\" \'::text) || ax_gemarkung.bezeichnung::text) || \' \'::text) || \
+                    ax_flurstueck.flurnummer::text) || \' \"\'::text) || \
+                    CASE \
+                        WHEN ax_flurstueck.nenner IS NULL THEN ax_flurstueck.zaehler::text \
+                        ELSE (ax_flurstueck.zaehler::text || \'/\'::text) || ax_flurstueck.nenner::text \
+                    END) || \'\" \'::text || ax_flurstueck.zaehler::text) @@ to_tsquery(\'german\', :search) \
+                ORDER BY ax_gemarkung.bezeichnung,flurstueckskennzeichen")
+            query.bindValue(":search", unicode(searchString))
             query.exec_()
             self.treeWidget.clear()
+            QgsMessageLog.logMessage(query.lastQuery())
             if(query.size() > 0):
                 fieldNrFlurst = query.record().indexOf("flurstueckskennzeichen")
                 fieldGemarkungsnummer = query.record().indexOf("gemarkungsnummer")
@@ -65,7 +95,7 @@ class PostNAS_SearchDialog(QtGui.QDialog, Ui_PostNAS_SearchDialogBase):
                     flurnummer = query.value(fieldFlurnummer)
                     zaehler = query.value(fieldZaehler)
                     nenner = query.value(fieldNenner)
-                    
+
                     if(self.treeWidget.topLevelItemCount() > 0):
                         for i in range(0, self.treeWidget.topLevelItemCount()):
                             if(self.treeWidget.topLevelItem(i).text(1) == str(gemarkungsnummer)):
@@ -83,7 +113,7 @@ class PostNAS_SearchDialog(QtGui.QDialog, Ui_PostNAS_SearchDialogBase):
                         item_gemarkung.setText(1, str(gemarkungsnummer))
                         item_gemarkung.setText(2, "gemarkung")
                         item_gemarkung.setText(3, "05" + str(gemarkungsnummer).zfill(4))
-                    
+
                     for i in range(0, item_gemarkung.childCount()):
                         if(item_gemarkung.child(i).text(1) == str(flurnummer)):
                             item_flur = item_gemarkung.child(i)
@@ -94,7 +124,7 @@ class PostNAS_SearchDialog(QtGui.QDialog, Ui_PostNAS_SearchDialogBase):
                         item_flur.setText(1, str(flurnummer))
                         item_flur.setText(2, "flur")
                         item_flur.setText(3, "05" + str(gemarkungsnummer).zfill(4) + str(flurnummer).zfill(3))
-                    
+
                     item_flst = QTreeWidgetItem(item_flur)
                     if(nenner == NULL):
                         item_flst.setText(0, str(zaehler))
@@ -102,21 +132,21 @@ class PostNAS_SearchDialog(QtGui.QDialog, Ui_PostNAS_SearchDialogBase):
                         item_flst.setText(0, str(zaehler) + " / " + str(nenner))
                     item_flst.setText(1, flurstuecknummer)
                     item_flst.setText(2, "flurstueck")
-                
+
                 self.showButton.setEnabled(True)
-                
+
                 # Gemarkung aufklappen, wenn nur eine vorhanden ist
                 if(self.treeWidget.topLevelItemCount() == 1):
                     self.treeWidget.expandItem(self.treeWidget.topLevelItem(0))
-                
+
                 # Flur aufklappen, wenn nur eine vorhanden ist
                 if(self.treeWidget.topLevelItem(0).childCount() == 1):
                     self.treeWidget.expandItem(self.treeWidget.topLevelItem(0).child(0))
-                
+
                 # Wenn nur ein Flurstück gefunden wurd, dieses direkt anzeigen
                 if (query.size() == 1):
                     self.addMapFlurstueck("'" + flurstuecknummer + "'")
-                
+
                 self.db.close()
             else:
                 item_gemarkung = QTreeWidgetItem(self.treeWidget)
@@ -124,7 +154,7 @@ class PostNAS_SearchDialog(QtGui.QDialog, Ui_PostNAS_SearchDialogBase):
         else:
             self.treeWidget.clear()
         QApplication.setOverrideCursor(Qt.ArrowCursor)
-    
+
     def on_treeWidget_itemDoubleClicked(self, item):
         if(item.text(2) == "flurstueck"):
             self.addMapFlurstueck("'" + item.text(1) + "'")
@@ -132,18 +162,18 @@ class PostNAS_SearchDialog(QtGui.QDialog, Ui_PostNAS_SearchDialogBase):
             self.addMapFlur(item.text(3))
         if(item.text(2) == "gemarkung"):
             self.addMapGemarkung(item.text(3))
-        
+
     def keyPressEvent(self, event):
         if (event.key() == QtCore.Qt.Key_Return or event.key() == QtCore.Qt.Key_Enter):
             self.on_showButton_pressed()
-        
+
     def on_resetButton_pressed(self):
         self.treeWidget.clear()
         self.lineEdit.clear()
         self.resetSuchergebnisLayer()
         self.showButton.setEnabled(False)
         self.resetButton.setEnabled(False)
-            
+
     def on_showButton_pressed(self):
         searchStringFlst = "";
         searchStringFlur = "";
@@ -161,49 +191,49 @@ class PostNAS_SearchDialog(QtGui.QDialog, Ui_PostNAS_SearchDialogBase):
                 if(len(searchStringGemarkung) > 0):
                     searchStringGemarkung += '|'
                 searchStringGemarkung += item.text(3)
-            
+
         if(len(searchStringGemarkung) > 0):
             self.addMapGemarkung(searchStringGemarkung)
             pass
-    
+
         if(len(searchStringFlur) > 0):
             self.addMapFlur(searchStringFlur)
             pass
-        
+
         if(len(searchStringFlst) > 0):
             self.addMapFlurstueck(searchStringFlst)
-    
+
     def addMapFlurstueck(self, searchString):
         if(len(searchString) > 0):
             self.resetSuchergebnisLayer()
-            
+
             uri = QgsDataSourceURI()
             uri.setConnection(self.dbHost, "5432", self.dbDatabasename, self.dbUsername, self.dbPassword)
             uri.setDataSource("public", "ax_flurstueck", "wkb_geometry", "flurstueckskennzeichen IN (" +  searchString + ")")
             vlayer = QgsVectorLayer(uri.uri(),  "Suchergebnis", "postgres")
-            
+
             self.addSuchergebnisLayer(vlayer)
-            
+
     def addMapFlur(self, searchString):
         if(len(searchString) > 0):
             self.resetSuchergebnisLayer()
-            
+
             uri = QgsDataSourceURI()
             uri.setConnection(self.dbHost, "5432", self.dbDatabasename, self.dbUsername, self.dbPassword)
             uri.setDataSource("public", "ax_flurstueck", "wkb_geometry", "flurstueckskennzeichen SIMILAR TO '(" +  searchString + ")%'")
             vlayer = QgsVectorLayer(uri.uri(),  "Suchergebnis", "postgres")
-            
+
             self.addSuchergebnisLayer(vlayer)
-            
+
     def addMapGemarkung(self, searchString):
         if(len(searchString) > 0):
             self.resetSuchergebnisLayer()
-            
+
             uri = QgsDataSourceURI()
             uri.setConnection(self.dbHost, "5432", self.dbDatabasename, self.dbUsername, self.dbPassword)
             uri.setDataSource("public", "ax_flurstueck", "wkb_geometry", "flurstueckskennzeichen SIMILAR TO '(" +  searchString + ")%'")
             vlayer = QgsVectorLayer(uri.uri(),  "Suchergebnis", "postgres")
-            
+
             self.addSuchergebnisLayer(vlayer)
 
     def addSuchergebnisLayer(self, vlayer):
@@ -215,29 +245,29 @@ class PostNAS_SearchDialog(QtGui.QDialog, Ui_PostNAS_SearchDialogBase):
         myRenderer = QgsSingleSymbolRendererV2(mySymbol1)
         vlayer.setRendererV2(myRenderer)
         vlayer.setBlendMode(13)
-        
+
         # Insert Layer at Top of Legend
         QgsMapLayerRegistry.instance().addMapLayer(vlayer, False)
         QgsProject.instance().layerTreeRoot().insertLayer(0, vlayer)
-        
+
         canvas = self.iface.mapCanvas()
         canvas.setExtent(vlayer.extent().buffer(50))
-        
+
         self.resetButton.setEnabled(True)
-    
+
     def resetSuchergebnisLayer(self):
          if(len(self.map.mapLayersByName("Suchergebnis")) > 0):
             self.map.removeMapLayer(self.map.mapLayersByName("Suchergebnis")[0].id())
-            
+
     def loadDbSettings(self):
         settings = QSettings("PostNAS", "PostNAS-Suche")
-        
+
         self.dbHost = settings.value("host", "")
         self.dbDatabasename = settings.value("dbname", "")
         self.dbPort = settings.value("port", "5432")
         self.dbUsername = settings.value("user", "")
         self.dbPassword = settings.value("password", "")
-                
+
         self.db = QSqlDatabase.addDatabase("QPSQL")
         self.db.setHostName(self.dbHost)
         self.db.setPort(int(self.dbPort))


### PR DESCRIPTION
Hallo Herr Brandt,

wie bereits in der Mail geschrieben, bietet die Suche mit tsvector den Vorteil, dass den Nutzern keine Suchstrategie vorgeben wird, d.h. die Suche funktioniert wie bisher zb. 0308-003-00004/001 aber auch (in diesem Beispiel) Wenigenjena 3 4/1. Bei mir (42000 Flurstücke, PostgreSQL-DB auf physischer Maschine) ist die Wartezeit auf eine Antwort unter einer Sekunde.
Im QGISWebClient haben wir mit der tsvector-basierten Suche gute Erfahrungen gemacht, siehe http://map.jena.de Sie können in das Suchfeld oben rechts beliebige Begriffe oder Namen eingeben.